### PR TITLE
Revert module path change.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The [manual](https://coredns.io/manual/toc/#what-is-coredns) will have more info
 A simple way to consume this plugin, is by adding the following on [plugin.cfg](https://github.com/coredns/coredns/blob/master/plugin.cfg), and recompile it as [detailed on coredns.io](https://coredns.io/2017/07/25/compile-time-enabling-or-disabling-plugins/#build-with-compile-time-configuration-file).
 
 ~~~
-gathersrv:github.com/allegro/gathersrv
+gathersrv:github.com/ziollek/gathersrv
 ~~~
 
 It is recommended to put this plugin right [after](https://github.com/coredns/coredns/blob/master/plugin.cfg#L37) `prometheus:metrics` (to properly measure processing time visible by clients) and with no exemption before `forward:forward`

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/allegro/gathersrv
+module github.com/ziollek/gathersrv
 
 go 1.24
 


### PR DESCRIPTION
Reverts allegro/gathersrv#4 because forks doesn't play well with module name change. A better approach is to use `go mod edit -replace github.com/ziollek/gathersrv=github.com/allegro/gathersrv@<version>` in application including this mod.